### PR TITLE
Change predicate, String field names & other minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Collection remaining = mapped.remove(Match.record(new Account(Name = 'Bar')));
 |-------------------|--------|-------------|
 | `Collection` 		| `filter(SObjectPredicate predicate)` 			| Returns a `Collection` view of records that satisfied predicate |
 
-Two predicates are provided out of the box, `FieldsMatch` and `RecordMatch`. They are instantiated through factory methods on `Match`:
+Three predicates are provided out of the box, `FieldsMatch`, `RecordMatch` and `ChangeMatch`. They are instantiated through factory methods on `Match`:
 
 ```apex
 Collection accountCollection = Collection.of(accounts);

--- a/src/classes/Change.cls
+++ b/src/classes/Change.cls
@@ -1,0 +1,6 @@
+public class Change {
+
+	public static ChangeMatch of(Map<Id, SObject> other) {
+		return new ChangeMatch(other);
+	}
+}

--- a/src/classes/Change.cls
+++ b/src/classes/Change.cls
@@ -3,4 +3,9 @@ public class Change {
 	public static ChangeMatch of(Map<Id, SObject> other) {
 		return new ChangeMatch(other);
 	}
+
+
+	public static ChangeMatch of(List<SObject> other) {
+		return new ChangeMatch(new Map<Id, SObject>(other));
+	}
 }

--- a/src/classes/Change.cls-meta.xml
+++ b/src/classes/Change.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ChangeMatch.cls
+++ b/src/classes/ChangeMatch.cls
@@ -1,0 +1,58 @@
+public class ChangeMatch implements SObjectPredicate {
+
+	private Map<Id, SObject> other;
+	private Set<String> fields = new Set<String>();
+
+	// CONSTRUCTOR
+
+	public ChangeMatch(Map<Id, SObject> other) {
+		this.other = other;
+	}
+
+
+	// PUBLIC
+
+	public ChangeMatch at(SObjectField field) {
+		return at(''+field);
+	}
+
+
+	public ChangeMatch at(List<SObjectField> fields) {
+		return at(nameList(fields));
+	}
+
+
+	public ChangeMatch at(String field) {
+		fields.add(field);
+		return this;
+	}
+
+
+	public ChangeMatch at(List<String> fields) {
+		this.fields.addAll(fields);
+		return this;
+	}
+
+
+	public Boolean apply(SObject record) {
+		for (String field : fields) {
+			if (record.get(field) != other.get(record.Id).get(field)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+
+	// PRIVATE
+
+	private List<String> nameList(List<SObjectField> fields) {
+		List<String> result = new List<String>();
+
+		for(SObjectField f : fields) {
+			result.add(''+f);
+		}
+
+		return result;
+	}
+}

--- a/src/classes/ChangeMatch.cls
+++ b/src/classes/ChangeMatch.cls
@@ -3,6 +3,7 @@ public class ChangeMatch implements SObjectPredicate {
 	private Map<Id, SObject> other;
 	private Set<String> fields = new Set<String>();
 
+
 	// CONSTRUCTOR
 
 	public ChangeMatch(Map<Id, SObject> other) {

--- a/src/classes/ChangeMatch.cls-meta.xml
+++ b/src/classes/ChangeMatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/Collection.cls
+++ b/src/classes/Collection.cls
@@ -2,317 +2,494 @@ public with sharing class Collection {
 
 	private List<SObject> records;
 
+
+	// CONSTRUCT
+
 	public static Collection of(Iterable<SObject> records) {
 		return new Collection(records);
 	}
+
 
 	public static Collection of(Set<SObject> records) {
 		return new Collection(new List<SObject>(records));
 	}
 
+
 	private Collection(Iterable<SObject> records) {
 		this.records = new List<SObject>();
+
 		Iterator<SObject> iter = records.iterator();
-		while (iter.hasNext()) {
+
+		while(iter.hasNext()) {
 			this.records.add(iter.next());
 		}
 	}
+
+
+	// CONVERT
 
 	public List<SObject> asList() {
 		return new List<SObject>(records);
 	}
 
+
 	public List<SObject> asList(Type listType) {
-		List<SObject> typedList = (List<SObject>) listType.newInstance();
+		List<SObject> typedList =(List<SObject>) listType.newInstance();
 		typedList.addAll(records);
 		return typedList;
 	}
+
 
 	public Set<SObject> asSet() {
 		return new Set<SObject>(records);
 	}
 
+
 	public Set<SObject> asSet(Type setType) {
-		Set<SObject> typedSet = (Set<SObject>) setType.newInstance();
+		Set<SObject> typedSet =(Set<SObject>) setType.newInstance();
 		typedSet.addAll(records);
 		return typedSet;
 	}
 
+
+	public Map<Id, SObject> asMap() {
+		return new Map<Id, SObject>(records);
+	}
+
+
+	public Map<Id, SObject> asMap(Type mapType) {
+		Map<Id, SObject> typedMap =(Map<Id, SObject>) mapType.newInstance();
+		typedMap.putAll(records);
+		return typedMap;
+	}
+
+
+	// FILTER
+
 	public Collection filter(SObjectPredicate predicate) {
-		List<SObject> filtered = new List<SObject>();
-		for (SObject record : records) {
-			if (predicate.apply(record)) {
-				filtered.add(record);
+		List<SObject> result = new List<SObject>();
+
+		for(SObject record : records) {
+			if(predicate.apply(record)) {
+				result.add(record);
 			}
 		}
-		return Collection.of(filtered);
+
+		return Collection.of(result);
 	}
+
 
 	public Collection remove(SObjectPredicate predicate) {
-		List<SObject> remaining = new List<SObject>();
-		for (SObject record : records) {
-			if (!predicate.apply(record)) {
-				remaining.add(record);
+		List<SObject> result = new List<SObject>();
+
+		for(SObject record : records) {
+			if(!predicate.apply(record)) {
+				result.add(record);
 			}
 		}
-		return Collection.of(remaining);
+
+		return Collection.of(result);
 	}
 
-	public List<Boolean> pluckBooleans(Schema.SObjectField field) {
-		List<Boolean> results = new List<Boolean>();
-		for (SObject rec : records) {
-			results.add((Boolean)rec.get(field));
-		}
-		return results;
-	}
 
-	public List<Boolean> pluckBooleans(String relation) {
-		List<Boolean> results = new List<Boolean>();
+	// EXTRACT
+
+	public List<Boolean> booleans(String fieldPath) {
+		List<Boolean> result = new List<Boolean>();
+
 		SObjectFieldReader reader = new SObjectFieldReader();
-		for (SObject rec : records) {
-			results.add((Boolean)reader.read(rec, relation));
+
+		for(SObject record : records) {
+			result.add((Boolean)reader.read(record, fieldPath));
 		}
-		return results;
+
+		return result;
 	}
 
-	public List<Date> pluckDates(Schema.SObjectField field) {
-		List<Date> results = new List<Date>();
-		for (SObject rec : records) {
-			results.add((Date)rec.get(field));
-		}
-		return results;
+
+	public List<Boolean> booleans(SObjectField field) {
+		return booleans(''+field);
 	}
 
-	public List<Date> pluckDates(String relation) {
-		List<Date> results = new List<Date>();
+
+	public Set<Boolean> booleanSet(SObjectField field) {
+		return new Set<Boolean>( booleans(field) );
+	}
+
+
+	public Set<Boolean> booleanSet(String fieldPath) {
+		return booleanSet('' + fieldPath);
+	}
+
+
+	public List<Date> dates(String fieldPath) {
+		List<Date> result = new List<Date>();
+
 		SObjectFieldReader reader = new SObjectFieldReader();
-		for (SObject rec : records) {
-			results.add((Date)reader.read(rec, relation));
+
+		for(SObject record : records) {
+			result.add((Date)reader.read(record, fieldPath));
 		}
-		return results;
+
+		return result;
 	}
 
-	public List<Datetime> pluckDatetimes(Schema.SObjectField field) {
-		List<Datetime> results = new List<Datetime>();
-		for (SObject rec : records) {
-			results.add((Datetime)rec.get(field));
-		}
-		return results;
+
+	public List<Date> dates(SObjectField field) {
+		return dates(''+field);
 	}
 
-	public List<Datetime> pluckDatetimes(String relation) {
-		List<Datetime> results = new List<Datetime>();
+
+	public Set<Date> dateSet(String field) {
+		return new Set<Date>(dates(field));
+	}
+
+
+	public Set<Date> dateSet(SObjectField field) {
+		return dateSet('' + field);
+	}
+
+
+	public List<Datetime> datetimes(String fieldPath) {
+		List<Datetime> result = new List<Datetime>();
+
 		SObjectFieldReader reader = new SObjectFieldReader();
-		for (SObject rec : records) {
-			results.add((Datetime)reader.read(rec, relation));
+
+		for(SObject record : records) {
+			result.add((Datetime)reader.read(record, fieldPath));
 		}
-		return results;
+
+		return result;
 	}
 
-	public List<Decimal> pluckDecimals(Schema.SObjectField field) {
-		List<Decimal> results = new List<Decimal>();
-		for (SObject rec : records) {
-			results.add((Decimal)rec.get(field));
-		}
-		return results;
+
+	public List<Datetime> datetimes(SObjectField field) {
+		return datetimes('' + field);
 	}
 
-	public List<Decimal> pluckDecimals(String relation) {
-		List<Decimal> results = new List<Decimal>();
+
+	public Set<Datetime> datetimeSet(String field) {
+		return new Set<Datetime>(datetimes(field));
+	}
+
+
+	public Set<Datetime> datetimeSet(SObjectField field) {
+		return datetimeSet('' + field);
+	}
+
+
+	public List<Decimal> decimals(String fieldPath) {
+		List<Decimal> result = new List<Decimal>();
+
 		SObjectFieldReader reader = new SObjectFieldReader();
-		for (SObject rec : records) {
-			results.add((Decimal)reader.read(rec, relation));
+
+		for(SObject record : records) {
+			result.add((Decimal)reader.read(record, fieldPath));
 		}
-		return results;
+
+		return result;
 	}
 
-	public List<Id> pluckIds() {
-		List<Id> results = new List<Id>();
-		for (SObject rec : records) {
-			results.add(rec.Id);
-		}
-		return results;
+
+	public List<Decimal> decimals(SObjectField field) {
+		return decimals(''+field);
 	}
 
-	public List<Id> pluckIds(Schema.SObjectField field) {
-		List<Id> results = new List<Id>();
-		for (SObject rec : records) {
-			results.add((Id)rec.get(field));
-		}
-		return results;
+
+	public Set<Decimal> decimalSet(String field) {
+		return new Set<Decimal>(decimals(field));
 	}
 
-	public List<Id> pluckIds(String relation) {
-		List<Id> results = new List<Id>();
+
+	public Set<Decimal> decimalSet(SObjectField field) {
+		return decimalSet(''+field);
+	}
+
+
+	public List<Id> ids(String fieldPath) {
+		List<Id> result = new List<Id>();
+
 		SObjectFieldReader reader = new SObjectFieldReader();
-		for (SObject rec : records) {
-			results.add((Id)reader.read(rec, relation));
+
+		for(SObject record : records) {
+			result.add((Id) reader.read(record, fieldPath));
 		}
-		return results;
+
+		return result;
 	}
 
-	public List<String> pluckStrings(Schema.SObjectField field) {
-		List<String> results = new List<String>();
-		for (SObject rec : records) {
-			results.add((String)rec.get(field));
-		}
-		return results;
+	public List<Id> ids() {
+		return ids('Id');
 	}
 
-	public List<String> pluckStrings(String relation) {
-		List<String> results = new List<String>();
+
+	public List<Id> ids(SObjectField field) {
+		return ids(''+field);
+	}
+
+
+	public Set<Id> idSet() {
+		return idSet('Id');
+	}
+
+
+	public Set<Id> idSet(String field) {
+		return new Set<Id>(ids(field));
+	}
+
+
+	public Set<Id> idSet(SObjectField field) {
+		return idSet(''+field);
+	}
+
+
+	public List<String> strings(SObjectField field) {
+		return strings(''+field);
+	}
+
+
+	public List<String> strings(String fieldPath) {
+		List<String> result = new List<String>();
+
 		SObjectFieldReader reader = new SObjectFieldReader();
-		for (SObject rec : records) {
-			results.add((String) reader.read(rec, relation));
+
+		for(SObject record : records) {
+			result.add((String) reader.read(record, fieldPath));
 		}
-		return results;
+
+		return result;
 	}
 
-	public Map<Boolean, List<SObject>> groupByBooleans(Schema.SObjectField field, Type listType) {
-		Map<Boolean, List<SObject>> grouped = new Map<Boolean, List<SObject>>();
-		for (SObject rec : records) {
-			Boolean key = (Boolean) rec.get(field);
-			if (!grouped.containsKey(key)) {
-				grouped.put(key, (List<SObject>) listType.newInstance());
-			}
-			grouped.get(key).add(rec);
-		}
-		return grouped;
+
+	public Set<String> stringSet(String field) {
+		return new Set<String>(strings(field));
 	}
 
-	public Map<Boolean, List<SObject>> groupByBooleans(Schema.SObjectField field) {
+
+	public Set<String> stringSet(SObjectField field) {
+		return stringSet(''+field);
+	}
+
+
+	// GROUP
+
+	public Map<Boolean, List<SObject>> groupByBooleans(SObjectField field) {
+		return groupByBooleans(''+field);
+	}
+
+
+	public Map<Boolean, List<SObject>> groupByBooleans(String field) {
 		return groupByBooleans(field, List<SObject>.class);
 	}
 
-	public Map<Date, List<SObject>> groupByDates(Schema.SObjectField field, Type listType) {
-		Map<Date, List<SObject>> grouped = new Map<Date, List<SObject>>();
-		for (SObject rec : records) {
-			Date key = (Date) rec.get(field);
-			if (!grouped.containsKey(key)) {
-				grouped.put(key, (List<SObject>) listType.newInstance());
-			}
-			grouped.get(key).add(rec);
-		}
-		return grouped;
+
+	public Map<Boolean, List<SObject>> groupByBooleans(SObjectField field, Type listType) {
+		return groupByBooleans(''+field, listType);
 	}
 
-	public Map<Datetime, List<SObject>> groupByDatetimes(Schema.SObjectField field) {
+
+	public Map<Boolean, List<SObject>> groupByBooleans(String field, Type listType) {
+		Map<Object, List<SObject>> result = groupByObjects(field, Boolean.class, listType);
+		return (Map<Boolean, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Boolean, List<SObject>>.class);
+	}
+
+
+	public Map<Datetime, List<SObject>> groupByDatetimes(SObjectField field) {
+		return groupByDatetimes(''+field);
+	}
+
+
+	public Map<Datetime, List<SObject>> groupByDatetimes(String field) {
 		return groupByDatetimes(field, List<SObject>.class);
 	}
 
-	public Map<Datetime, List<SObject>> groupByDatetimes(Schema.SObjectField field, Type listType) {
-		Map<Datetime, List<SObject>> grouped = new Map<Datetime, List<SObject>>();
-		for (SObject rec : records) {
-			Datetime key = (Datetime) rec.get(field);
-			if (!grouped.containsKey(key)) {
-				grouped.put(key, (List<SObject>) listType.newInstance());
-			}
-			grouped.get(key).add(rec);
-		}
-		return grouped;
+
+	public Map<Datetime, List<SObject>> groupByDatetimes(SObjectField field, Type listType) {
+		return groupByDatetimes(''+field, listType);
 	}
 
-	public Map<Date, List<SObject>> groupByDates(Schema.SObjectField field) {
+
+	public Map<Datetime, List<SObject>> groupByDatetimes(String field, Type listType) {
+		Map<Object, List<SObject>> result = groupByObjects(field, Datetime.class, listType);
+		return (Map<Datetime, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Datetime, List<SObject>>.class);
+	}
+
+
+	public Map<Date, List<SObject>> groupByDates(SObject field) {
+		return groupByDates(''+field);
+	}
+
+
+	public Map<Date, List<SObject>> groupByDates(String field) {
 		return groupByDates(field, List<SObject>.class);
 	}
 
-	public Map<Decimal, List<SObject>> groupByDecimals(Schema.SObjectField field, Type listType) {
-		Map<Decimal, List<SObject>> grouped = new Map<Decimal, List<SObject>>();
-		for (SObject rec : records) {
-			Decimal key = (Decimal) rec.get(field);
-			if (!grouped.containsKey(key)) {
-				grouped.put(key, (List<SObject>) listType.newInstance());
-			}
-			grouped.get(key).add(rec);
-		}
-		return grouped;
+
+	public Map<Date, List<SObject>> groupByDates(SObjectField field, Type listType) {
+		return groupByDates(''+field, listType);
 	}
 
-	public Map<Decimal, List<SObject>> groupByDecimals(Schema.SObjectField field) {
+
+	public Map<Date, List<SObject>> groupByDates(String field, Type listType) {
+		Map<Object, List<SObject>> result = groupByObjects(field, Date.class, listType);
+		return (Map<Date, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Date, List<SObject>>.class);
+	}
+
+
+	public Map<Decimal, List<SObject>> groupByDecimals(SObjectField field) {
+		return groupByDecimals(''+field);
+	}
+
+
+	public Map<Decimal, List<SObject>> groupByDecimals(String field) {
 		return groupByDecimals(field, List<SObject>.class);
 	}
 
-	public Map<Id, List<SObject>> groupByIds(Schema.SObjectField field, Type listType) {
-		Map<Id, List<SObject>> grouped = new Map<Id, List<SObject>>();
-		for (SObject rec : records) {
-			Id key = (Id) rec.get(field);
-			if (!grouped.containsKey(key)) {
-				grouped.put(key, (List<SObject>) listType.newInstance());
-			}
-			grouped.get(key).add(rec);
-		}
-		return grouped;
+
+	public Map<Decimal, List<SObject>> groupByDecimals(SObjectField field, Type listType) {
+		return groupByDecimals(''+field, listType);
 	}
 
-	public Map<Id, List<SObject>> groupByIds(Schema.SObjectField field) {
+
+	public Map<Decimal, List<SObject>> groupByDecimals(String field, Type listType) {
+		Map<Object, List<SObject>> result = groupByObjects(field, Decimal.class, listType);
+		return (Map<Decimal, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Decimal, List<SObject>>.class);
+	}
+
+
+	public Map<Id, List<SObject>> groupByIds(SObjectField field) {
+		return groupByIds(''+field);
+	}
+
+
+	public Map<Id, List<SObject>> groupByIds(String field) {
 		return groupByIds(field, List<SObject>.class);
 	}
 
-	public Map<String, List<SObject>> groupByStrings(Schema.SObjectField field, Type listType) {
-		Map<String, List<SObject>> grouped = new Map<String, List<SObject>>();
-		for (SObject rec : records) {
-			String key = (String) rec.get(field);
-			if (!grouped.containsKey(key)) {
-				grouped.put(key, (List<SObject>) listType.newInstance());
-			}
-			grouped.get(key).add(rec);
-		}
-		return grouped;
+
+	public Map<Id, List<SObject>> groupByIds(SObjectField field, Type listType) {
+		return groupByIds(''+field, listType);
 	}
 
-	public Map<String, List<SObject>> groupByStrings(Schema.SObjectField field) {
+
+	public Map<Id, List<SObject>> groupByIds(String field, Type listType) {
+		Map<Object, List<SObject>> result = groupByObjects(field, Id.class, listType);
+		return (Map<Id, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Id, List<SObject>>.class);
+	}
+
+
+	public Map<String, List<SObject>> groupByStrings(SObjectField field) {
+		return groupByStrings(''+field);
+	}
+
+
+	public Map<String, List<SObject>> groupByStrings(String field) {
 		return groupByStrings(field, List<SObject>.class);
 	}
 
-	public Collection pick(List<Schema.SObjectField> fields) {
-		return pick(new Set<Schema.SObjectField>(fields));
+
+	public Map<String, List<SObject>> groupByStrings(SObjectField field, Type listType) {
+		return groupByStrings(''+field, listType);
 	}
 
-	public Collection pick(Set<Schema.SObjectField> fields) {
-		Set<String> fieldNames = new Set<String>();
-		for (Schema.SObjectField field : fields) {
-			Schema.DescribeFieldResult describe = field.getDescribe();
-			fieldNames.add(describe.getName());
+
+	public Map<String, List<SObject>> groupByStrings(String field, Type listType) {
+		Map<Object, List<SObject>> result = groupByObjects(field, String.class, listType);
+		return (Map<String, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<String, List<SObject>>.class);
+	}
+
+
+	public Map<Object, List<SObject>> groupByObjects(String field, Type objectType, Type listType) {
+		Map<Object, List<SObject>> result = new Map<Object, List<SObject>>();
+
+		for(SObject record : records) {
+			Object key = JSON.deserialize(JSON.serialize(record.get(field)), objectType);
+
+			if(!result.containsKey(key)) {
+				result.put(key,(List<SObject>) listType.newInstance());
+			}
+
+			result.get(key).add(record);
 		}
-		return pick(fieldNames);
+
+		return result;
 	}
 
-	public Collection pick(Set<String> apiFieldNames) {
+
+	// PICK
+
+	public Collection pick(List<SObjectField> fields) {
+		return pick(stringList(fields));
+	}
+
+
+	public Collection pick(Set<SObjectField> fields) {
+		return pick(new List<SObjectField>(fields));
+	}
+
+	public Collection pick(Set<String> fields) {
 		List<SObject> picked = new List<SObject>();
-		for (SObject record : records) {
+
+		for(SObject record : records) {
 			SObject result = record.getSObjectType().newSObject();
 			Map<String, Object> fieldMap = record.getPopulatedFieldsAsMap();
-			for (String fieldName : apiFieldNames) {
-				if (fieldMap.containsKey(fieldName)) {
+
+			for(String fieldName : fields) {
+				if(fieldMap.containsKey(fieldName)) {
 					result.put(fieldName, record.get(fieldName));
 				}
 			}
+
 			picked.add(result);
 		}
+
 		return Collection.of(picked);
 	}
 
-	public Collection pick(List<String> apiFieldNames) {
-		return pick(new Set<String>(apiFieldNames));
+
+	public Collection pick(List<String> fields) {
+		return pick(new Set<String>(fields));
 	}
+
+
+	// MAP
 
 	public Collection mapAll(SObjectToSObjectFunction fn) {
-		List<SObject> mapped = new List<SObject>();
-		for (SObject record : records) {
-			mapped.add(fn.apply(record));
+		List<SObject> result = new List<SObject>();
+
+		for(SObject record : records) {
+			result.add(fn.apply(record));
 		}
-		return Collection.of(mapped);
+
+		return Collection.of(result);
 	}
 
+
 	public Collection mapSome(SObjectPredicate predicate, SObjectToSObjectFunction fn) {
-		List<SObject> transformed = new List<SObject>();
-		for (SObject record : records) {
-			if (predicate.apply(record)) {
-				transformed.add(fn.apply(record));
-			} else {
-				transformed.add(record);
+		List<SObject> result = new List<SObject>();
+
+		for(SObject record : records) {
+			if(predicate.apply(record)) {
+				result.add(fn.apply(record));
+			}
+			else {
+				result.add(record);
 			}
 		}
-		return Collection.of(transformed);
+
+		return Collection.of(result);
+	}
+
+
+	// PRIVATE
+
+	private List<String> stringList(List<SObjectField> fields) {
+		List<String> result = new List<String>();
+
+		for(SObjectField f : fields) {
+			result.add(''+f);
+		}
+
+		return result;
 	}
 }

--- a/src/classes/Collection.cls
+++ b/src/classes/Collection.cls
@@ -100,7 +100,7 @@ public with sharing class Collection {
 		SObjectFieldReader reader = new SObjectFieldReader();
 
 		for(SObject record : records) {
-			result.add((Boolean)reader.read(record, fieldPath));
+			result.add((Boolean) reader.read(record, fieldPath));
 		}
 
 		return result;
@@ -128,7 +128,7 @@ public with sharing class Collection {
 		SObjectFieldReader reader = new SObjectFieldReader();
 
 		for(SObject record : records) {
-			result.add((Date)reader.read(record, fieldPath));
+			result.add((Date) reader.read(record, fieldPath));
 		}
 
 		return result;
@@ -156,7 +156,7 @@ public with sharing class Collection {
 		SObjectFieldReader reader = new SObjectFieldReader();
 
 		for(SObject record : records) {
-			result.add((Datetime)reader.read(record, fieldPath));
+			result.add((Datetime) reader.read(record, fieldPath));
 		}
 
 		return result;
@@ -184,7 +184,7 @@ public with sharing class Collection {
 		SObjectFieldReader reader = new SObjectFieldReader();
 
 		for(SObject record : records) {
-			result.add((Decimal)reader.read(record, fieldPath));
+			result.add((Decimal) reader.read(record, fieldPath));
 		}
 
 		return result;
@@ -289,8 +289,14 @@ public with sharing class Collection {
 
 
 	public Map<Boolean, List<SObject>> groupByBooleans(String field, Type listType) {
-		Map<Object, List<SObject>> result = groupByObjects(field, Boolean.class, listType);
-		return (Map<Boolean, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Boolean, List<SObject>>.class);
+		Map<Boolean, List<SObject>> result = new Map<Boolean, List<SObject>>();
+
+		Map<Object, List<SObject>> grouped = groupByObjects(field, listType);
+		for(Object key : grouped.keySet()) {
+			result.put((Boolean) key, grouped.get(key));
+		}
+
+		return result;
 	}
 
 
@@ -310,8 +316,14 @@ public with sharing class Collection {
 
 
 	public Map<Datetime, List<SObject>> groupByDatetimes(String field, Type listType) {
-		Map<Object, List<SObject>> result = groupByObjects(field, Datetime.class, listType);
-		return (Map<Datetime, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Datetime, List<SObject>>.class);
+		Map<Datetime, List<SObject>> result = new Map<Datetime, List<SObject>>();
+
+		Map<Object, List<SObject>> grouped = groupByObjects(field, listType);
+		for(Object key : grouped.keySet()) {
+			result.put((Datetime) key, grouped.get(key));
+		}
+
+		return result;
 	}
 
 
@@ -331,8 +343,14 @@ public with sharing class Collection {
 
 
 	public Map<Date, List<SObject>> groupByDates(String field, Type listType) {
-		Map<Object, List<SObject>> result = groupByObjects(field, Date.class, listType);
-		return (Map<Date, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Date, List<SObject>>.class);
+		Map<Date, List<SObject>> result = new Map<Date, List<SObject>>();
+
+		Map<Object, List<SObject>> grouped = groupByObjects(field, listType);
+		for(Object key : grouped.keySet()) {
+			result.put((Date) key, grouped.get(key));
+		}
+
+		return result;
 	}
 
 
@@ -352,8 +370,14 @@ public with sharing class Collection {
 
 
 	public Map<Decimal, List<SObject>> groupByDecimals(String field, Type listType) {
-		Map<Object, List<SObject>> result = groupByObjects(field, Decimal.class, listType);
-		return (Map<Decimal, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Decimal, List<SObject>>.class);
+		Map<Decimal, List<SObject>> result = new Map<Decimal, List<SObject>>();
+
+		Map<Object, List<SObject>> grouped = groupByObjects(field, listType);
+		for(Object key : grouped.keySet()) {
+			result.put((Decimal) key, grouped.get(key));
+		}
+
+		return result;
 	}
 
 
@@ -373,8 +397,14 @@ public with sharing class Collection {
 
 
 	public Map<Id, List<SObject>> groupByIds(String field, Type listType) {
-		Map<Object, List<SObject>> result = groupByObjects(field, Id.class, listType);
-		return (Map<Id, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<Id, List<SObject>>.class);
+		Map<Id, List<SObject>> result = new Map<Id, List<SObject>>();
+
+		Map<Object, List<SObject>> grouped = groupByObjects(field, listType);
+		for(Object key : grouped.keySet()) {
+			result.put((Id) key, grouped.get(key));
+		}
+
+		return result;
 	}
 
 
@@ -394,16 +424,22 @@ public with sharing class Collection {
 
 
 	public Map<String, List<SObject>> groupByStrings(String field, Type listType) {
-		Map<Object, List<SObject>> result = groupByObjects(field, String.class, listType);
-		return (Map<String, List<SObject>>) JSON.deserialize(JSON.serialize(result), Map<String, List<SObject>>.class);
+		Map<String, List<SObject>> result = new Map<String, List<SObject>>();
+
+		Map<Object, List<SObject>> grouped = groupByObjects(field, listType);
+		for(Object key : grouped.keySet()) {
+			result.put((String) key, grouped.get(key));
+		}
+
+		return result;
 	}
 
 
-	public Map<Object, List<SObject>> groupByObjects(String field, Type objectType, Type listType) {
+	public Map<Object, List<SObject>> groupByObjects(String field, Type listType) {
 		Map<Object, List<SObject>> result = new Map<Object, List<SObject>>();
 
 		for(SObject record : records) {
-			Object key = JSON.deserialize(JSON.serialize(record.get(field)), objectType);
+			Object key = record.get(field);
 
 			if(!result.containsKey(key)) {
 				result.put(key,(List<SObject>) listType.newInstance());

--- a/src/classes/CollectionTest.cls
+++ b/src/classes/CollectionTest.cls
@@ -6,16 +6,19 @@ public class CollectionTest {
 
 	static List<Account> testAccounts() {
 		return new List<Account>{
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Foo', AnnualRevenue = 100),
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Bar', AnnualRevenue = 60),
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Foo', AnnualRevenue = 150),
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Bar', AnnualRevenue = 150)
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Foo', AnnualRevenue = 100),
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Bar', AnnualRevenue = 60),
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Foo', AnnualRevenue = 150),
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Bar', AnnualRevenue = 150)
 		};
 	}
 
+
 	@IsTest
 	public static void testPluckDecimals() {
-		List<Decimal> revenues = Collection.of(testAccounts()).pluckDecimals(Account.AnnualRevenue);
+		List<Decimal> revenues = Collection.of(testAccounts()).decimals(Account.AnnualRevenue);
+
+		// Verify
 		System.assertEquals(4, revenues.size());
 		System.assertEquals(100.0, revenues[0]);
 		System.assertEquals(60.0, revenues[1]);
@@ -23,9 +26,12 @@ public class CollectionTest {
 		System.assertEquals(150.0, revenues[3]);
 	}
 
+
 	@IsTest
 	public static void testPluckStrings() {
-		List<String> names = Collection.of(testAccounts()).pluckStrings(Account.Name);
+		List<String> names = Collection.of(testAccounts()).strings(Account.Name);
+
+		// Verify
 		System.assertEquals(4, names.size());
 		System.assertEquals('Foo', names[0]);
 		System.assertEquals('Bar', names[1]);
@@ -33,9 +39,12 @@ public class CollectionTest {
 		System.assertEquals('Bar', names[3]);
 	}
 
+
 	@IsTest
 	public static void testPluckIdsAsStrings() {
-		List<String> ownerIds = Collection.of(testAccounts()).pluckStrings(Account.OwnerId);
+		List<String> ownerIds = Collection.of(testAccounts()).strings(Account.OwnerId);
+
+		// Verify
 		System.assertEquals(4, ownerIds.size());
 		System.assertEquals(firstUserId, ownerIds[0]);
 		System.assertEquals(firstUserId, ownerIds[1]);
@@ -43,9 +52,12 @@ public class CollectionTest {
 		System.assertEquals(secondUserId, ownerIds[3]);
 	}
 
+
 	@IsTest
 	public static void testPluckIds() {
-		List<Id> ownerIds = Collection.of(testAccounts()).pluckIds(Account.OwnerId);
+		List<Id> ownerIds = Collection.of(testAccounts()).ids(Account.OwnerId);
+
+		// Verify
 		// workaround for List.contains bug
 		Set<Id> idSet = new Set<Id>(ownerIds);
 		System.assertEquals(2, idSet.size());
@@ -53,10 +65,13 @@ public class CollectionTest {
 		System.assert(idSet.contains(secondUserId));
 	}
 
+
 	@IsTest
 	public static void testPluckRecordIds() {
 		List<Account> accounts = testAccounts();
-		List<Id> recordIds = Collection.of(accounts).pluckIds();
+		List<Id> recordIds = Collection.of(accounts).ids();
+
+		// Verify
 		System.assertEquals(4, recordIds.size());
 		// workaround for List.contains bug
 		Set<Id> idSet = new Set<Id>(recordIds);
@@ -66,29 +81,34 @@ public class CollectionTest {
 		System.assert(idSet.contains(accounts[3].Id));
 	}
 
+
 	@IsTest
 	public static void testPluckBooleans() {
 		List<User> users = new List<User>{
-			new User(Title = 'Foo', IsActive = true),
-			new User(Title = 'Bar', IsActive = true),
-			new User(Title = 'Baz', IsActive = false)
+							new User(Title = 'Foo', IsActive = true),
+							new User(Title = 'Bar', IsActive = true),
+							new User(Title = 'Baz', IsActive = false)
 		};
-		List<Boolean> active = Collection.of(users).pluckBooleans(User.IsActive);
+		List<Boolean> active = Collection.of(users).booleans(User.IsActive);
+
+		// Verify
 		System.assertEquals(3, active.size());
 		System.assertEquals(true, active[0]);
 		System.assertEquals(true, active[1]);
 		System.assertEquals(false, active[2]);
 	}
 
+
 	@IsTest
 	public static void testFieldsMatchFilter() {
 		Collection c = Collection.of(new List<Account>{
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Foo', AnnualRevenue = 100),
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Bar', AnnualRevenue = 60),
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Foo', AnnualRevenue = 150),
-			new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Bar', AnnualRevenue = 150)
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Foo', AnnualRevenue = 100),
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = firstUserId, Name = 'Bar', AnnualRevenue = 60),
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Foo', AnnualRevenue = 150),
+							new Account(Id = TestUtility.getTestId(Account.SObjectType), OwnerId = secondUserId, Name = 'Bar', AnnualRevenue = 150)
 		});
 
+		// Verify
 		List<Account> filtered = c.filter(Match.field(Account.AnnualRevenue).eq(150)).asList();
 		System.assertEquals(2, filtered.size());
 
@@ -97,10 +117,13 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	public static void testGroupByStrings() {
 		Collection c = Collection.of(testAccounts());
 		Map<String, List<Account>> accountsByName = c.groupByStrings(Account.Name);
+
+		// Verify
 		System.assertEquals(2, accountsByName.size());
 		System.assert(accountsByName.keySet().contains('Foo'));
 		System.assert(accountsByName.keySet().contains('Bar'));
@@ -114,27 +137,34 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	public static void testGroupByStringTyping() {
 		Collection c = Collection.of(testAccounts());
 		Map<String, List<Account>> accountsByName = c.groupByStrings(Account.Name);
 		List<Account> fooAccounts = accountsByName.get('Foo');
 		List<SObject> objects = fooAccounts;
+
+		// Verify
 		// since fooAccounts points to a returned list of SObjects, it can be anything!
 		System.assert(objects instanceof List<Opportunity>);
 
-		accountsByName = c.groupBystrings(Account.Name, List<Account>.class);
+		accountsByName = c.groupByStrings(Account.Name, List<Account>.class);
 		fooAccounts = accountsByName.get('Foo');
 		objects = fooAccounts;
+
 		// this time around, it works fine!
 		System.assert(!(objects instanceof List<Opportunity>));
 		System.assert(objects instanceof List<Account>);
 	}
 
+
 	@IsTest
 	public static void testGroupByDecimals() {
 		Collection c = Collection.of(testAccounts());
 		Map<Decimal, List<Account>> accountsByRevenue = c.groupByDecimals(Account.AnnualRevenue);
+
+		// Verify
 		System.assertEquals(3, accountsByRevenue.size());
 		System.assert(accountsByRevenue.keySet().contains(60));
 		System.assert(accountsByRevenue.keySet().contains(100));
@@ -147,10 +177,13 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	public static void testGroupByIds() {
 		Collection c = Collection.of(testAccounts());
 		Map<Id, List<Account>> accountsByOwners = c.groupByIds(Account.OwnerId);
+
+		// Verify
 		System.assertEquals(2, accountsByOwners.size());
 		System.assert(accountsByOwners.keySet().contains(firstUserId));
 		System.assert(accountsByOwners.keySet().contains(secondUserId));
@@ -161,14 +194,17 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	public static void testGroupByBooleans() {
 		Collection c = Collection.of(new List<User>{
-			new User(Title = 'Foo', IsActive = true),
-			new User(Title = 'Bar', IsActive = true),
-			new User(Title = 'Baz', IsActive = false)
+							new User(Title = 'Foo', IsActive = true),
+							new User(Title = 'Bar', IsActive = true),
+							new User(Title = 'Baz', IsActive = false)
 		});
 		Map<Boolean, List<User>> usersByActive = c.groupByBooleans(User.IsActive);
+
+		// Verify
 		System.assertEquals(2, usersByActive.size());
 		System.assert(usersByActive.keySet().contains(true));
 		System.assert(usersByActive.keySet().contains(false));
@@ -179,23 +215,29 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	public static void pickShouldPickFields() {
 		Collection c = Collection.of(new List<Account>{
-			new Account(Name = 'Test1', AnnualRevenue = 100),
-			new Account(Name = 'Test2', AnnualRevenue = 200)
+							new Account(Name = 'Test1', AnnualRevenue = 100),
+							new Account(Name = 'Test2', AnnualRevenue = 200)
 		});
+
+		// Verify
 		verifyNamePick(c.pick(new List<Schema.SObjectField>{Account.Name}));
 		verifyNamePick(c.pick(new Set<Schema.SObjectField>{Account.Name}));
 		verifyNamePick(c.pick(new List<String>{'Name'}));
 		verifyNamePick(c.pick(new Set<String>{'Name'}));
 	}
 
+
 	@IsTest
 	public static void pickedFieldsShouldHaveValues() {
 		Collection c = Collection.of(new List<Opportunity>{
-			new Opportunity(Name = 'Test', Amount = 100, Description = 'Test description')
+							new Opportunity(Name = 'Test', Amount = 100, Description = 'Test description')
 		});
+
+		// Verify
 		List<Opportunity> picked = c.pick(new List<String>{'Name', 'Amount'}).asList();
 		System.assertEquals(1, picked.size());
 		for (Opportunity opp : picked) {
@@ -204,73 +246,67 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	public static void pickShouldPickHeterogenousRecords() {
 		Collection c = Collection.of(new List<SObject>{
-			new Account(Name = 'Test1', AnnualRevenue = 100),
-			new Opportunity(Name = 'Test1', Description = 'Test description')
+							new Account(Name = 'Test1', AnnualRevenue = 100),
+							new Opportunity(Name = 'Test1', Description = 'Test description')
 		});
+
+		// Verify
 		verifyNamePick(c.pick(new List<String>{'Name'}));
 		verifyNamePick(c.pick(new Set<String>{'Name'}));
 	}
 
+
 	@IsTest
 	public static void pickShouldHaveMatchingObjectTypes() {
 		Collection c = Collection.of(new List<SObject>{
-			new Account(Name = 'Test1', AnnualRevenue = 100),
-			new Opportunity(Name = 'Test1', Description = 'Test description')
+							new Account(Name = 'Test1', AnnualRevenue = 100),
+							new Opportunity(Name = 'Test1', Description = 'Test description')
 		});
 		List<SObject> picked = c.pick(new List<String>{'Name'}).asList();
+
+		// Verify
 		System.assertEquals(Account.sObjectType, picked[0].getSObjectType(), 'First picked element should be an Account.');
 		System.assertEquals(Opportunity.sObjectType, picked[1].getSObjectType(), 'Second picked element should be an Opportunity.');
 	}
 
-	private static void verifyNamePick(Collection picked) {
-		for (SObject obj : picked.asList()) {
-			Map<String, Object> fields = obj.getPopulatedFieldsAsMap();
-			System.assertEquals(1, fields.size());
-			System.assert(fields.containsKey('Name'));
-		}
-	}
-
-	static List<Account> testFilterAccounts() {
-		List<Account> accounts = new List<Account>{
-			new Account(Name = 'Ok', AnnualRevenue = 100),
-			new Account(Name = 'Wrong', AnnualRevenue = 60),
-			new Account(Name = 'Ok', AnnualRevenue = 150),
-			new Account(Name = 'Wrong', AnnualRevenue = 150)
-		};
-		return accounts;
-	}
 
 	@IsTest
 	static void testRelationalFiltering() {
 		List<Account> accounts = new List<Account>{
-			new Account(Name = 'Ok', AnnualRevenue = 100),
-			new Account(Name = 'Wrong', AnnualRevenue = 60)
+							new Account(Name = 'Ok', AnnualRevenue = 100),
+							new Account(Name = 'Wrong', AnnualRevenue = 60)
 		};
 		List<Opportunity> opps = new List<Opportunity>{
-			new Opportunity(
-				Name = 'First',
-				CloseDate = Date.today().addDays(3),
-				Account = accounts[0]
-			),
-			new Opportunity(
-				Name = 'Second',
-				CloseDate = Date.today().addDays(6),
-				Account = accounts[1]
-			)
+							new Opportunity(
+												Name = 'First',
+												CloseDate = Date.today().addDays(3),
+												Account = accounts[0]
+							),
+							new Opportunity(
+												Name = 'Second',
+												CloseDate = Date.today().addDays(6),
+												Account = accounts[1]
+							)
 		};
 		Collection c = Collection.of(opps);
 		List<Opportunity> filtered = (List<Opportunity>) c.filter(Match.field('Account.AnnualRevenue').greaterThan(70)).asList();
+
+		// Verify
 		System.assertEquals(1, filtered.size());
 		System.assertEquals('First', filtered[0].Name);
 	}
+
 
 	@IsTest
 	static void testHasValue() {
 		Collection c = Collection.of(testFilterAccounts());
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.Industry).hasValue()).asList();
+
+		// Verify
 		System.assertEquals(0, filtered.size());
 
 		filtered = (List<Account>) c.filter(Match.field(Account.Name).hasValue()).asList();
@@ -278,38 +314,46 @@ public class CollectionTest {
 
 	}
 
+
 	@IsTest
 	static void testIsIn() {
 		Collection c = Collection.of(testFilterAccounts());
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.AnnualRevenue).isIn(new Set<Decimal>{60, 150})).asList();
+
+		// Verify
 		System.assertEquals(3, filtered.size());
 		for (Account acc : filtered) {
 			System.assert(acc.AnnualRevenue == 60 || acc.AnnualRevenue == 150);
 		}
 	}
 
+
 	@IsTest
 	static void testIsNotIn() {
 		Collection c = Collection.of(testFilterAccounts());
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.AnnualRevenue).notIn(new Set<Decimal>{60})).asList();
+
+		// Verify
 		System.assertEquals(3, filtered.size());
 		for (Account acc : filtered) {
 			System.assert(acc.AnnualRevenue == 100 || acc.AnnualRevenue == 150);
 		}
 	}
 
+
 	@IsTest
 	static void testFieldEqualsOkFilter() {
 		Collection c = Collection.of(testFilterAccounts());
 
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.Name).equals('Ok')).asList();
+		List<Account> remaining = (List<Account>) c.remove(Match.field(Account.Name).equals('Ok')).asList();
+
+		// Verify
 
 		System.assertEquals(2, filtered.size());
 		for (Account acc : filtered) {
 			System.assertEquals('Ok', acc.Name);
 		}
-
-		List<Account> remaining = (List<Account>) c.remove(Match.field(Account.Name).equals('Ok')).asList();
 
 		System.assertEquals(2, remaining.size());
 		for (Account acc : remaining) {
@@ -317,10 +361,13 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	static void testMultipleFieldFilter() {
 		Collection c = Collection.of(testFilterAccounts());
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.Name).equals('Ok').also(Account.AnnualRevenue).gt(100)).asList();
+
+		// Verify
 
 		System.assertEquals(1, filtered.size());
 		for (Account acc : filtered) {
@@ -336,9 +383,12 @@ public class CollectionTest {
 		}
 	}
 
+
 	@IsTest
 	static void testSameFieldTokenExclusionCriteria() {
 		Collection c = Collection.of(testFilterAccounts());
+
+		// Verify
 
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.Name).equals('Ok').also(Account.Name).neq('Ok')).asList();
 		System.assertEquals(0, filtered.size());
@@ -346,11 +396,14 @@ public class CollectionTest {
 		List<Account> remaining = (List<Account>) c.remove(Match.field(Account.Name).equals('Ok').also(Account.Name).neq('Ok')).asList();
 		System.assertEquals(4, remaining.size());
 	}
+
 
 	@IsTest
 	static void testSameFieldExclusionCriteria() {
 		Collection c = Collection.of(testFilterAccounts());
 
+		// Verify
+
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.Name).equals('Ok').also(Account.Name).neq('Ok')).asList();
 		System.assertEquals(0, filtered.size());
 
@@ -358,9 +411,12 @@ public class CollectionTest {
 		System.assertEquals(4, remaining.size());
 	}
 
+
 	@IsTest
 	static void testLongChaining() {
 		Collection c = Collection.of(testFilterAccounts());
+
+		// Verify
 
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.Name).equals('Ok').also(Account.AnnualRevenue).lt(150).also(Account.AnnualRevenue).geq(100)).asList();
 		System.assertEquals(1, filtered.size());
@@ -369,9 +425,12 @@ public class CollectionTest {
 		System.assertEquals(3, remaining.size());
 	}
 
+
 	@IsTest
 	static void testSameFieldSandwichCriteria() {
 		Collection c = Collection.of(testFilterAccounts());
+
+		// Verify
 
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.AnnualRevenue).lt(150).also(Account.AnnualRevenue).gt(60)).asList();
 		System.assertEquals(1, filtered.size());
@@ -379,17 +438,21 @@ public class CollectionTest {
 		List<Account> remaining = (List<Account>) c.remove(Match.field(Account.AnnualRevenue).lt(150).also(Account.AnnualRevenue).gt(60)).asList();
 		System.assertEquals(3, remaining.size());
 	}
+
 
 	@IsTest
 	static void testSameTokenSandwichCriteria() {
 		Collection c = Collection.of(testFilterAccounts());
 
+		// Verify
+
 		List<Account> filtered = (List<Account>) c.filter(Match.field(Account.AnnualRevenue).lt(150).also(Account.AnnualRevenue).gt(60)).asList();
 		System.assertEquals(1, filtered.size());
 
 		List<Account> remaining = (List<Account>) c.remove(Match.field(Account.AnnualRevenue).lt(150).also(Account.AnnualRevenue).gt(60)).asList();
 		System.assertEquals(3, remaining.size());
 	}
+
 
 	@IsTest
 	static void testComparisonFilter() {
@@ -407,6 +470,20 @@ public class CollectionTest {
 			System.assertNotEquals(150, acc.AnnualRevenue);
 		}
 	}
+
+
+	@IsTest
+	static void testChangeFilter() {
+
+		// Setup
+		Collection c = Collection.of( new List<Opportunity>{ new Opportunity(Amount=100), new Opportunity(Amount=150) } );
+		Map<Id, Opportunity> after = (Map<Id, Opportunity>) c.mapSome(Match.field('Amount').eq(100), new DoubleAmount())
+																.asMap(Map<Id, Opportunity>.class);
+
+		List<Opportunity> changed = (List<Opportunity>) c.filter(Change.of(after).at(Opportunity.Amount)).asList();
+		System.assertEquals(1, changed.size());
+	}
+
 
 	@IsTest
 	static void testListTyping() {
@@ -430,42 +507,76 @@ public class CollectionTest {
 		System.assert(remainingWithoutType instanceof List<Opportunity>);
 	}
 
-	private class DoubleAmount implements SObjectToSObjectFunction {
-		public SObject apply(SObject record) {
-			record.put('Amount', 2 * (Decimal) record.get('Amount'));
-			return record;
-		}
-	}
 
 	@IsTest
 	static void testMapAll() {
 		List<Opportunity> opportunities = Collection.of(new List<Opportunity>{
-			new Opportunity(Amount = 100),
-			new Opportunity(Amount = 150)
+							new Opportunity(Amount = 100),
+							new Opportunity(Amount = 150)
 		}).mapAll(new DoubleAmount()).asList();
+
+		// Verify
 		System.assertEquals(2, opportunities.size());
 		System.assertEquals(200, opportunities[0].Amount);
 		System.assertEquals(300, opportunities[1].Amount);
 	}
 
+
 	@IsTest
 	static void testMapSome() {
 		List<Opportunity> opportunities = Collection.of(new List<Opportunity>{
-			new Opportunity(Amount = 100),
-			new Opportunity(Amount = 150)
+							new Opportunity(Amount = 100),
+							new Opportunity(Amount = 150)
 		}).mapSome(Match.field('Amount').eq(100), new DoubleAmount()).asList();
+
+		// Verify
 		System.assertEquals(2, opportunities.size());
 		System.assertEquals(200, opportunities[0].Amount);
 		System.assertEquals(150, opportunities[1].Amount);
 	}
 
+
 	@IsTest
 	static void testMapWithTransform() {
 		List<Opportunity> opportunities = Collection.of(new List<Opportunity>{
-			new Opportunity(Amount = 100),
-			new Opportunity(Amount = 150)
+							new Opportunity(Amount = 100),
+							new Opportunity(Amount = 150)
 		}).mapAll(Transform.record(new Opportunity(Amount = 123))).asList();
+
+		// Verify
 		System.assertEquals(123, opportunities[0].Amount);
 		System.assertEquals(123, opportunities[1].Amount);
+	}
+
+
+	// HELPER
+
+	private static void verifyNamePick(Collection picked) {
+		for (SObject obj : picked.asList()) {
+			Map<String, Object> fields = obj.getPopulatedFieldsAsMap();
+
+			// Verify
+			System.assertEquals(1, fields.size());
+			System.assert(fields.containsKey('Name'));
+		}
+	}
+
+
+	static List<Account> testFilterAccounts() {
+		List<Account> accounts = new List<Account>{
+							new Account(Name = 'Ok', AnnualRevenue = 100),
+							new Account(Name = 'Wrong', AnnualRevenue = 60),
+							new Account(Name = 'Ok', AnnualRevenue = 150),
+							new Account(Name = 'Wrong', AnnualRevenue = 150)
+		};
+		return accounts;
+	}
+
+
+	private class DoubleAmount implements SObjectToSObjectFunction {
+		public SObject apply(SObject record) {
+			record.put('Amount', 2 * (Decimal) record.get('Amount'));
+			return record;
+		}
 	}
 }


### PR DESCRIPTION
I find your library super useful but had to adapt it to replace my own implementation in our product code. I would be super exited if I could merge those changes back into you repo.

- Add `ChangeMatch` predicate to filter changes on DML
- Added `asMap()`
- Refactored `pluck<Type>` to return `<Type>Set` and `<Type>List`
- Added formatting (space)
- Added methods to also work with String field names